### PR TITLE
Promote form link to button

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -1,5 +1,5 @@
 format: jb-book
-root: README
+root: index
 parts:
   - caption: Essential info
     chapters:

--- a/index.md
+++ b/index.md
@@ -1,0 +1,16 @@
+```{include} README.md
+:end-before: Easy, just fill out
+```
+
+Click below to get started!
+
+````{dropdown} I've read the summary and am ready to sign up!
+:icon: checklist
+:animate: fade-in-slide-down
+
+```{button-link} https://forms.gle/rGzGWfDigLgpB2H29
+:expand:
+:shadow:
+:color: secondary
+Sign Up Here!
+```


### PR DESCRIPTION
On the rendered site, I've promoted the form link to a more prominent button, with the additional step of clicking through a dropdown that hopefully encourages explicitly reading the goals of the hackathon:

<img width="829" alt="image" src="https://user-images.githubusercontent.com/24628426/231234234-572c6e74-65c4-4e8f-96c2-a0c52a22e305.png">

To keep `README.md` usable on eg GitHub, I've separated these but just include most of `README.md` into `index` to avoid duplication.