### PR TITLE
Update table of contents for new python environments

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -6,3 +6,4 @@ parts:
       - file: schedule
       - file: travel
       - file: faq
+      - file: python-environments

--- a/python-environments.md
+++ b/python-environments.md
@@ -1,4 +1,4 @@
-# Getting Python On Your Machine: Mamba :snake:!
+# Getting Python On Your Machine: Mamba!
 
 ---
 


### PR DESCRIPTION
The python environments section is currently missing - this adds it in.
